### PR TITLE
Move xhr shim in Rex::Exploitation::Js::Network to be shared

### DIFF
--- a/data/js/network/ajax_download.js
+++ b/data/js/network/ajax_download.js
@@ -1,11 +1,7 @@
 function ajax_download(oArg) {
-  var method = oArg.method;
-  var path   = oArg.path;
-  var data   = oArg.data;
-
-  if (method == undefined) { method = "GET"; }
-  if (method == path)      { throw "Missing parameter 'path'"; }
-  if (data   == undefined) { data = null; }
+  if (!oArg.method) { oArg.method = "GET"; }
+  if (!oArg.path)   { throw "Missing parameter 'path'"; }
+  if (!oArg.data)   { oArg.data = null; }
 
   var xmlHttp = new XMLHttpRequest();
 
@@ -13,8 +9,8 @@ function ajax_download(oArg) {
     xmlHttp.overrideMimeType("text/plain; charset=x-user-defined");
   }
 
-  xmlHttp.open(method, path, false);
-  xmlHttp.send(data);
+  xmlHttp.open(oArg.method, oArg.path, false);
+  xmlHttp.send(oArg.data);
   if (xmlHttp.readyState == 4 && xmlHttp.status == 200) {
     return xmlHttp.responseText;
   }

--- a/data/js/network/ajax_download.js
+++ b/data/js/network/ajax_download.js
@@ -7,19 +7,7 @@ function ajax_download(oArg) {
   if (method == path)      { throw "Missing parameter 'path'"; }
   if (data   == undefined) { data = null; }
 
-  if (window.XMLHttpRequest) {
-    xmlHttp = new XMLHttpRequest();
-  }
-  else {
-    var objs = ["Microsoft.XMLHTTP", "Msxml2.XMLHTTP", "Msxml2.XMLHTTP.4.0"];
-    for (var i=0; i < objs.length; i++) {
-      try {
-        xmlHttp = new ActiveXObject(objs[i]);
-        break;
-      }
-      catch (e) {}
-    }
-  }
+  var xmlHttp = new XMLHttpRequest();
 
   if (xmlHttp.overrideMimeType) {
     xmlHttp.overrideMimeType("text/plain; charset=x-user-defined");

--- a/data/js/network/ajax_post.js
+++ b/data/js/network/ajax_post.js
@@ -1,18 +1,5 @@
 function postInfo(path, data) {
-  var xmlHttp = '';
-  if (window.XMLHttpRequest) {
-    xmlHttp = new XMLHttpRequest();
-  }
-  else {
-    var objs = ["Microsoft.XMLHTTP", "Msxml2.XMLHTTP", "Msxml2.XMLHTTP.4.0"];
-    for (var i=0; i < objs.length; i++) {
-      try {
-        xmlHttp = new ActiveXObject(objs[i]);
-        break;
-      }
-      catch (e) {}
-    }
-  }
+  var xmlHttp = new XMLHttpRequest();
 
   if (xmlHttp.overrideMimeType) {
     xmlHttp.overrideMimeType("text/plain; charset=x-user-defined");

--- a/data/js/network/xhr_shim.js
+++ b/data/js/network/xhr_shim.js
@@ -1,0 +1,13 @@
+if (!window.XMLHTTPRequest) {
+  var i, ids = ["Microsoft.XMLHTTP", "Msxml2.XMLHTTP", "Msxml2.XMLHTTP.6.0", "Msxml2.XMLHTTP.3.0"];
+  for (i = 0; i < ids.length; i++) {
+    try {
+      new ActiveXObject(ids[i]);
+      window.XMLHttpRequest = function() {
+        return new ActiveXObject(ids[i]);
+      };
+      break;
+    }
+    catch (e) {}
+  }
+}

--- a/data/js/network/xhr_shim.js
+++ b/data/js/network/xhr_shim.js
@@ -1,13 +1,15 @@
 if (!window.XMLHTTPRequest) {
-  var idx, activeObjs = ["Microsoft.XMLHTTP", "Msxml2.XMLHTTP", "Msxml2.XMLHTTP.6.0", "Msxml2.XMLHTTP.3.0"];
-  for (idx = 0; idx < activeObjs.length; idx++) {
-    try {
-      new ActiveXObject(activeObjs[idx]);
-      window.XMLHttpRequest = function() {
-        return new ActiveXObject(activeObjs[idx]);
-      };
-      break;
+  (function() {
+    var idx, activeObjs = ["Microsoft.XMLHTTP", "Msxml2.XMLHTTP", "Msxml2.XMLHTTP.6.0", "Msxml2.XMLHTTP.3.0"];
+    for (idx = 0; idx < activeObjs.length; idx++) {
+      try {
+        new ActiveXObject(activeObjs[idx]);
+        window.XMLHttpRequest = function() {
+          return new ActiveXObject(activeObjs[idx]);
+        };
+        break;
+      }
+      catch (e) {}
     }
-    catch (e) {}
-  }
+  })();
 }

--- a/data/js/network/xhr_shim.js
+++ b/data/js/network/xhr_shim.js
@@ -1,10 +1,10 @@
 if (!window.XMLHTTPRequest) {
-  var i, ids = ["Microsoft.XMLHTTP", "Msxml2.XMLHTTP", "Msxml2.XMLHTTP.6.0", "Msxml2.XMLHTTP.3.0"];
-  for (i = 0; i < ids.length; i++) {
+  var idx, activeObjs = ["Microsoft.XMLHTTP", "Msxml2.XMLHTTP", "Msxml2.XMLHTTP.6.0", "Msxml2.XMLHTTP.3.0"];
+  for (idx = 0; idx < activeObjs.length; idx++) {
     try {
-      new ActiveXObject(ids[i]);
+      new ActiveXObject(activeObjs[idx]);
       window.XMLHttpRequest = function() {
-        return new ActiveXObject(ids[i]);
+        return new ActiveXObject(activeObjs[idx]);
       };
       break;
     }

--- a/lib/rex/exploitation/js/network.rb
+++ b/lib/rex/exploitation/js/network.rb
@@ -13,7 +13,7 @@ class Network
 
   # @param [Hash] opts the options hash
   # @option opts [Boolean] :obfuscate toggles js obfuscation. defaults to true.
-  # @option opts [Boolean] :use_xhr_shim automatically stubs XHR to use ActiveXObject when needed.
+  # @option opts [Boolean] :inject_xhr_shim automatically stubs XHR to use ActiveXObject when needed.
   #   defaults to true.
   # @return [String] javascript code to perform a synchronous ajax request to the remote
   #   and returns the response
@@ -35,7 +35,7 @@ class Network
 
   # @param [Hash] opts the options hash
   # @option opts [Boolean] :obfuscate toggles js obfuscation. defaults to true.
-  # @option opts [Boolean] :use_xhr_shim automatically stubs XHR to use ActiveXObject when needed.
+  # @option opts [Boolean] :inject_xhr_shim automatically stubs XHR to use ActiveXObject when needed.
   #   defaults to true.
   # @return [String] javascript code to perform a synchronous ajax request to the remote with
   #   the data specified
@@ -57,11 +57,11 @@ class Network
 
   # @param [Hash] opts the options hash
   # @option opts [Boolean] :obfuscate toggles js obfuscation. defaults to true.
-  # @option opts [Boolean] :use_xhr_shim false causes this method to return ''. defaults to true.
+  # @option opts [Boolean] :inject_xhr_shim false causes this method to return ''. defaults to true.
   # @return [String] javascript code that adds XMLHttpRequest to the global scope if it
   #   does not exist (e.g. on IE6, where you have to use the ActiveXObject constructor)
   def self.xhr_shim(opts={})
-    return '' unless opts.fetch(:use_xhr_shim, true)
+    return '' unless opts.fetch(:inject_xhr_shim, true)
 
     should_obfuscate = opts.fetch(:obfuscate, true)
     js = ::File.read(::File.join(Msf::Config.data_directory, "js", "network", "xhr_shim.js"))

--- a/lib/rex/exploitation/js/network.rb
+++ b/lib/rex/exploitation/js/network.rb
@@ -11,27 +11,70 @@ module Js
 #
 class Network
 
-  def self.ajax_download
+  # @param [Hash] opts the options hash
+  # @option opts [Boolean] :obfuscate toggles js obfuscation. defaults to true.
+  # @option opts [Boolean] :use_xhr_shim automatically stubs XHR to use ActiveXObject when needed.
+  #   defaults to true.
+  # @return [String] javascript code to perform a synchronous ajax request to the remote
+  #   and returns the response
+  def self.ajax_download(opts={})
+    should_obfuscate = opts.fetch(:obfuscate, true)
     js = ::File.read(::File.join(Msf::Config.data_directory, "js", "network", "ajax_download.js"))
 
-    ::Rex::Exploitation::ObfuscateJS.new(js,
-      {
-        'Symbols' => {
-          'Variables' => %w{ xmlHttp }
-        }
+    if should_obfuscate
+      js = ::Rex::Exploitation::ObfuscateJS.new(js,
+        {
+          'Symbols' => {
+            'Variables' => %w{ xmlHttp }
+          }
       }).obfuscate
+    end
+
+    xhr_shim(opts) + js
   end
 
+  # @param [Hash] opts the options hash
+  # @option opts [Boolean] :obfuscate toggles js obfuscation. defaults to true.
+  # @option opts [Boolean] :use_xhr_shim automatically stubs XHR to use ActiveXObject when needed.
+  #   defaults to true.
+  # @return [String] javascript code to perform a synchronous ajax request to the remote with
+  #   the data specified
+  def self.ajax_post(opts={})
+    should_obfuscate = opts.fetch(:obfuscate, true)
+    js = :File.read(::File.join(Msf::Config.data_directory, "js", "network", "ajax_post.js"))
 
-  def self.ajax_post
-    js = ::File.read(::File.join(Msf::Config.data_directory, "js", "network", "ajax_post.js"))
+    if should_obfuscate
+      ::Rex::Exploitation::ObfuscateJS.new(js,
+        {
+          'Symbols' => {
+            'Variables' => %w{ xmlHttp }
+          }
+        }).obfuscate
+    end
 
-    ::Rex::Exploitation::ObfuscateJS.new(js,
-      {
-        'Symbols' => {
-          'Variables' => %w{ xmlHttp }
+    xhr_shim(opts) + js
+  end
+
+  # @param [Hash] opts the options hash
+  # @option opts [Boolean] :obfuscate toggles js obfuscation. defaults to true.
+  # @option opts [Boolean] :use_xhr_shim false causes this method to return ''. defaults to true.
+  # @return [String] javascript code that adds XMLHttpRequest to the global scope if it
+  #   does not exist (e.g. on IE6, where you have to use the ActiveXObject constructor)
+  def self.xhr_shim(opts={})
+    return '' unless opts.fetch(:use_xhr_shim, true)
+
+    should_obfuscate = opts.fetch(:obfuscate, true)
+    js = ::File.read(::File.join(Msf::Config.data_directory, "js", "network", "xhr_shim.js"))
+
+    if should_obfuscate
+      ::Rex::Exploitation::ObfuscateJS.new(js,
+        {
+          'Symbols' => {
+            'Variables' => %w{ i objs }
+          }
         }
-      }).obfuscate
+      ).obfuscate
+    end
   end
 
 end

--- a/lib/rex/exploitation/js/network.rb
+++ b/lib/rex/exploitation/js/network.rb
@@ -25,7 +25,7 @@ class Network
       js = ::Rex::Exploitation::ObfuscateJS.new(js,
         {
           'Symbols' => {
-            'Variables' => %w{ xmlHttp }
+            'Variables' => %w{ xmlHttp oArg }
           }
       }).obfuscate
     end
@@ -41,10 +41,10 @@ class Network
   #   the data specified
   def self.ajax_post(opts={})
     should_obfuscate = opts.fetch(:obfuscate, true)
-    js = :File.read(::File.join(Msf::Config.data_directory, "js", "network", "ajax_post.js"))
+    js = ::File.read(::File.join(Msf::Config.data_directory, "js", "network", "ajax_post.js"))
 
     if should_obfuscate
-      ::Rex::Exploitation::ObfuscateJS.new(js,
+      js = ::Rex::Exploitation::ObfuscateJS.new(js,
         {
           'Symbols' => {
             'Variables' => %w{ xmlHttp }
@@ -67,14 +67,15 @@ class Network
     js = ::File.read(::File.join(Msf::Config.data_directory, "js", "network", "xhr_shim.js"))
 
     if should_obfuscate
-      ::Rex::Exploitation::ObfuscateJS.new(js,
+      js = ::Rex::Exploitation::ObfuscateJS.new(js,
         {
           'Symbols' => {
-            'Variables' => %w{ i objs }
+            'Variables' => %w{ activeObjs idx }
           }
         }
       ).obfuscate
     end
+    js
   end
 
 end

--- a/spec/lib/rex/exploitation/js/network_spec.rb
+++ b/spec/lib/rex/exploitation/js/network_spec.rb
@@ -11,6 +11,14 @@ describe Rex::Exploitation::Js::Network do
       end
     end
 
+    context ".ajax_download" do
+      it "should load the ajax_post javascript" do
+        js = Rex::Exploitation::Js::Network.ajax_download
+        js.should =~ /function ajax_post/
+      end
+
+    end
+
   end
 
 end

--- a/spec/lib/rex/exploitation/js/network_spec.rb
+++ b/spec/lib/rex/exploitation/js/network_spec.rb
@@ -11,10 +11,10 @@ describe Rex::Exploitation::Js::Network do
       end
     end
 
-    context ".ajax_download" do
-      it "should load the ajax_post javascript" do
-        js = Rex::Exploitation::Js::Network.ajax_download
-        js.should =~ /function ajax_post/
+    context ".ajax_post" do
+      it "should load the postInfo javascript" do
+        js = Rex::Exploitation::Js::Network.ajax_post
+        js.should =~ /function postInfo/
       end
 
     end


### PR DESCRIPTION
- Moves the shim to its own file
- Also adds some yardoc to these static methods.
- Updates some of the Obfuscation to cover all vars
- Adds a spec for ajax_post
