### PR TITLE
Remove blanket pending test for exe_spec

### DIFF
--- a/spec/lib/msf/util/exe_spec.rb
+++ b/spec/lib/msf/util/exe_spec.rb
@@ -12,8 +12,6 @@ describe Msf::Util::EXE do
     described_class
   end
 
-  before { pending "Pending RM#8463, fix all these these tests up." }
-
   $framework = Msf::Simple::Framework.create(
     :module_types => [ Msf::MODULE_NOP ],
     'DisableDatabase' => true


### PR DESCRIPTION
I'd like to see if the rspec checks now pass completely if we un-mask the pending tests for exe_spec, please.
## Verification
- [x] Run rspec on an OSX machine before landing this fix.
- [x] Run rspec on an OSX machine after.

You should see your number of pending tests go down, as exe_spec is now being tested.
