### PR TITLE
Add http socket to the module sockets array and allow the framework to cleanup

### DIFF
--- a/modules/auxiliary/admin/appletv/appletv_display_image.rb
+++ b/modules/auxiliary/admin/appletv/appletv_display_image.rb
@@ -62,33 +62,30 @@ class Metasploit4 < Msf::Auxiliary
   def send_image_request(opts)
     http = nil
 
-    begin
-      http = Rex::Proto::Http::Client.new(
-        rhost,
-        rport.to_i,
-        {
-          'Msf' => framework,
-          'MsfExploit' => self
-        },
-        ssl,
-        ssl_version,
-        proxies,
-        datastore['USERNAME'],
-        datastore['PASSWORD']
-      )
+    http = Rex::Proto::Http::Client.new(
+      rhost,
+      rport.to_i,
+      {
+        'Msf' => framework,
+        'MsfExploit' => self
+      },
+      ssl,
+      ssl_version,
+      proxies,
+      datastore['USERNAME'],
+      datastore['PASSWORD']
+    )
+    add_socket(http)
 
-      http.set_config('agent' => datastore['UserAgent'])
+    http.set_config('agent' => datastore['UserAgent'])
 
-      req = http.request_raw(opts)
-      res = http.send_recv(req)
+    req = http.request_raw(opts)
+    res = http.send_recv(req)
 
-      sleep(datastore['TIME']) if res.code == 200
-      http.close
-    ensure
-      cleanup
-    end
+    Rex.sleep(datastore['TIME']) if res.code == 200
+    http.close
 
-    http
+    res
   end
 
 

--- a/modules/auxiliary/admin/appletv/appletv_display_video.rb
+++ b/modules/auxiliary/admin/appletv/appletv_display_video.rb
@@ -65,32 +65,29 @@ class Metasploit4 < Msf::Auxiliary
   def send_video_request(opts)
     http = nil
 
-    begin
-      http = Rex::Proto::Http::Client.new(
-        rhost,
-        rport.to_i,
-        {
-          'Msf' => framework,
-          'MsfExploit' => self
-        },
-        ssl,
-        ssl_version,
-        proxies,
-        datastore['USERNAME'],
-        datastore['PASSWORD']
-      )
+    http = Rex::Proto::Http::Client.new(
+      rhost,
+      rport.to_i,
+      {
+        'Msf' => framework,
+        'MsfExploit' => self
+      },
+      ssl,
+      ssl_version,
+      proxies,
+      datastore['USERNAME'],
+      datastore['PASSWORD']
+    )
+    add_socket(http)
 
-      http.set_config('agent' => datastore['UserAgent'])
+    http.set_config('agent' => datastore['UserAgent'])
 
-      req = http.request_raw(opts)
-      res = http.send_recv(req)
-      sleep(datastore['TIME']) if res.code == 200
-      http.close
-    ensure
-      cleanup
-    end
+    req = http.request_raw(opts)
+    res = http.send_recv(req)
+    Rex.sleep(datastore['TIME']) if res.code == 200
+    http.close
 
-    http
+    res
   end
 
 


### PR DESCRIPTION
Two small changes:
- Just add the http socket to the module sockets array with `add_socket` and allow the framework to `cleanup` instead of calling it from the own module. Shouldn't be a problem, but just to avoid an early cleanup.
- `send_image_request` and `send_video_request` were returning `http`. I'm guessing they were intended to return `res`. Do you mind to confirm? I cannot test! Please, feel free to verify, accept or decline any change and ready to go!
