### PR TITLE
Make safer Change AllowWin32SEH

### DIFF
--- a/modules/exploits/windows/browser/orbit_connecting.rb
+++ b/modules/exploits/windows/browser/orbit_connecting.rb
@@ -29,6 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/xmplay_asx.rb
+++ b/modules/exploits/windows/browser/xmplay_asx.rb
@@ -28,10 +28,10 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'BID', '21206'],
           [ 'URL', 'http://secunia.com/advisories/22999/' ],
         ],
-
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/acdsee_xpm.rb
+++ b/modules/exploits/windows/fileformat/acdsee_xpm.rb
@@ -32,6 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'EXITFUNC' => 'process',
           'DisablePayloadHandler' => 'true',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/adobe_illustrator_v14_eps.rb
+++ b/modules/exploits/windows/fileformat/adobe_illustrator_v14_eps.rb
@@ -31,6 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'EXITFUNC' => 'seh',
           'DisablePayloadHandler' => 'true',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/audio_wkstn_pls.rb
+++ b/modules/exploits/windows/fileformat/audio_wkstn_pls.rb
@@ -32,6 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'EXITFUNC' => 'seh',
           'DisablePayloadHandler' => 'true',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/blazedvd_plf.rb
+++ b/modules/exploits/windows/fileformat/blazedvd_plf.rb
@@ -35,7 +35,8 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'process'
+          'EXITFUNC' => 'process',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {
@@ -43,6 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "\x00\x0a\x1a",
           'DisableNops'  =>  true
         },
+
       'Platform' => 'win',
       'Targets'        =>
         [

--- a/modules/exploits/windows/fileformat/cain_abel_4918_rdp.rb
+++ b/modules/exploits/windows/fileformat/cain_abel_4918_rdp.rb
@@ -34,6 +34,10 @@ class Metasploit3 < Msf::Exploit::Remote
           'EncoderType'   => Msf::Encoder::Type::AlphanumMixed,
           'StackAdjustment' => -3500,
         },
+      'DefaultOptions' =>
+        {
+          'AllowWin32SEH' => true
+        },
       'Platform' => 'win',
       'Targets'        =>
         [

--- a/modules/exploits/windows/fileformat/destinymediaplayer16.rb
+++ b/modules/exploits/windows/fileformat/destinymediaplayer16.rb
@@ -33,6 +33,10 @@ class Metasploit3 < Msf::Exploit::Remote
           'EncoderType'   => Msf::Encoder::Type::AlphanumMixed,
           'StackAdjustment' => -3500,
         },
+      'DefaultOptions' =>
+        {
+          'AllowWin32SEH' => true
+        },
       'Platform' => 'win',
       'Targets'        =>
         [

--- a/modules/exploits/windows/fileformat/ezip_wizard_bof.rb
+++ b/modules/exploits/windows/fileformat/ezip_wizard_bof.rb
@@ -47,6 +47,10 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'EncoderType'   => Msf::Encoder::Type::AlphanumMixed,
         },
+      'DefaultOptions' =>
+        {
+          'AllowWin32SEH' => true
+        },
       'Targets'        =>
         [
           ['Windows Universal', { 'Offset' => 58, 'Ret' => 0x10020710 }],

--- a/modules/exploits/windows/fileformat/ht_mp3player_ht3_bof.rb
+++ b/modules/exploits/windows/fileformat/ht_mp3player_ht3_bof.rb
@@ -39,6 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/safenet_softremote_groupname.rb
+++ b/modules/exploits/windows/fileformat/safenet_softremote_groupname.rb
@@ -32,6 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'EXITFUNC' => 'process',
           'DisablePayloadHandler' => 'true',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/vuplayer_cue.rb
+++ b/modules/exploits/windows/fileformat/vuplayer_cue.rb
@@ -29,6 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'EXITFUNC' => 'process',
           'DisablePayloadHandler' => 'true',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/vuplayer_m3u.rb
+++ b/modules/exploits/windows/fileformat/vuplayer_m3u.rb
@@ -29,6 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'EXITFUNC' => 'process',
           'DisablePayloadHandler' => 'true',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/zinfaudioplayer221_pls.rb
+++ b/modules/exploits/windows/fileformat/zinfaudioplayer221_pls.rb
@@ -37,6 +37,10 @@ class Metasploit3 < Msf::Exploit::Remote
           'EncoderType'   => Msf::Encoder::Type::AlphanumMixed,
           'StackAdjustment' => -3500,
         },
+      'DefaultOptions' =>
+        {
+          'AllowWin32SEH' => true
+        },
       'Platform' => 'win',
       'Targets'        =>
         [

--- a/modules/exploits/windows/games/racer_503beta5.rb
+++ b/modules/exploits/windows/games/racer_503beta5.rb
@@ -34,6 +34,10 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "\x5c\x00",
           'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,
         },
+      'DefaultOptions' =>
+        {
+          'AllowWin32SEH' => true
+        },
       'Platform'       => 'win',
       'Targets'        =>
         [

--- a/modules/exploits/windows/http/amlibweb_webquerydll_app.rb
+++ b/modules/exploits/windows/http/amlibweb_webquerydll_app.rb
@@ -37,6 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions'	=>
         {
           'EXITFUNC'	=> 'thread',
+          'AllowWin32SEH' => true
         },
       'Payload'		=>
         {

--- a/modules/exploits/windows/http/apache_mod_rewrite_ldap.rb
+++ b/modules/exploits/windows/http/apache_mod_rewrite_ldap.rb
@@ -39,6 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'thread',
+          'AllowWin32SEH' => true
         },
       'Privileged'     => true,
       'Platform'       => ['win'],

--- a/modules/exploits/windows/http/belkin_bulldog.rb
+++ b/modules/exploits/windows/http/belkin_bulldog.rb
@@ -30,6 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/http/steamcast_useragent.rb
+++ b/modules/exploits/windows/http/steamcast_useragent.rb
@@ -35,6 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'thread',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/imap/novell_netmail_auth.rb
+++ b/modules/exploits/windows/imap/novell_netmail_auth.rb
@@ -30,6 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'thread',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/bigant_server.rb
+++ b/modules/exploits/windows/misc/bigant_server.rb
@@ -31,6 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/bigant_server_250.rb
+++ b/modules/exploits/windows/misc/bigant_server_250.rb
@@ -36,6 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'seh',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/borland_interbase.rb
+++ b/modules/exploits/windows/misc/borland_interbase.rb
@@ -28,6 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'thread',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/poppeeper_date.rb
+++ b/modules/exploits/windows/misc/poppeeper_date.rb
@@ -30,6 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/poppeeper_uidl.rb
+++ b/modules/exploits/windows/misc/poppeeper_uidl.rb
@@ -30,6 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/talkative_response.rb
+++ b/modules/exploits/windows/misc/talkative_response.rb
@@ -27,6 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/windows_rsh.rb
+++ b/modules/exploits/windows/misc/windows_rsh.rb
@@ -30,6 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'thread',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/nntp/ms05_030_nntp.rb
+++ b/modules/exploits/windows/nntp/ms05_030_nntp.rb
@@ -28,6 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/novell/groupwisemessenger_client.rb
+++ b/modules/exploits/windows/novell/groupwisemessenger_client.rb
@@ -28,6 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/proxy/qbik_wingate_wwwproxy.rb
+++ b/modules/exploits/windows/proxy/qbik_wingate_wwwproxy.rb
@@ -30,6 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
+          'AllowWin32SEH' => true
         },
       'Payload'        =>
         {


### PR DESCRIPTION
Hello @wchen-r7, this PR is related to https://github.com/rapid7/metasploit-framework/pull/4724

Since it is changing default behavior of two encoders, and unfortunately there are a lot of modules forcing these encoders, but not providing `BufferRegister` I think would be good to set `AllowWin32SEH` as `true` as `DefaultOptions` so, hopefully, the old behavior remains. Ideally these modules should be rewritten to a) Don't force the encoder to use, b) Provide BufferRegister. But since I don't think we can accomplish that task in a reasonable time... trying to make it just safer by no changing the old behavior. What do you think.
