### PR TITLE
Use compatible_payloads instead of copy and paste

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -707,36 +707,9 @@ class Exploit < Msf::Module
   # @return [FalseClass] Payload is not compatible.
   #
   def is_payload_compatible?(payload_name)
-    c_platform = (target and target.platform) ? target.platform : platform
-    c_arch     = (target and target.arch)     ? target.arch     : (arch == []) ? nil : arch
-    c_arch   ||= [ ARCH_X86 ]
+    payload_names = compatible_payloads.collect { |entry| entry[0] }
 
-    framework.payloads.each_module(
-      'Platform' => c_platform,
-      'Arch'     => c_arch ) { |name, mod|
-
-      # Skip over payloads that are too big
-      if ((payload_space) and
-          (framework.payloads.sizes[name]) and
-          (framework.payloads.sizes[name] > payload_space))
-        dlog("#{refname}: Skipping payload #{name} for being too large", 'core',
-          LEV_1)
-        next
-      end
-
-      # Are we compatible in terms of conventions and connections and
-      # what not?
-      next if (compatible?(framework.payloads.instance(name)) == false)
-
-      # If the payload is privileged but the exploit does not give
-      # privileged access, then fail it.
-      next if (self.privileged == false and framework.payloads.instance(name).privileged == true)
-
-      # This one be compatible!
-      return true if payload_name == name
-    }
-
-    false
+    payload_names.include?(payload_name)
   end
 
   #


### PR DESCRIPTION
Hi @wchen-r7,

It looks like `is_payload_compatible?` is reusing a lot of code from `compatible_payload`. I don't think worths the code duplication here. Even when in the best/average case reusing `compatible_payloads` will be slower, I don't think it's enough to duplicate code here. 

Here is my proposal! What do you think?

If you feel strong about exiting the loop as soon as you find the requested payload, I understand. But in that case I feel like code should be refactored!
