### PR TITLE
A number of small fixes for BAPv2

### DIFF
--- a/lib/msf/core/exploit/browser_autopwnv2.rb
+++ b/lib/msf/core/exploit/browser_autopwnv2.rb
@@ -140,10 +140,9 @@ module Msf
       xploit.datastore['DisablePayloadHandler'] = true
       xploit.datastore['BrowserProfilePrefix']  = browser_profile_prefix
       xploit.datastore['URIPATH']               = "/#{assign_module_resource}"
-      xploit.datastore['WORKSPACE']             = self.workspace
 
-      # TODO: Add BAPv2 tracking information (?) - HD
-      # TODO: Change exploit output options?     - HD
+      # Register this module as a child and copy datastore options
+      xploit.register_parent(self)
     end
 
 
@@ -152,12 +151,13 @@ module Msf
     # @param resource [String] The resource to check.
     # @return [TrueClass] Resource is taken.
     # @return [FalseClass] Resource is not taken.
-    # TODO: Prevent partial prefix match - HD
     def is_resource_taken?(resource)
       taken = false
 
       bap_exploits.each do |m|
-        return true if m.datastore['URIPATH'] == resource
+        # Prevent partial matching of one resource within another
+        return true if m.datastore['URIPATH'].index(resource)
+        return true if resource.index(m.datastore['URIPATH'])
       end
 
       taken
@@ -206,8 +206,10 @@ module Msf
     # @return [Hash] A hash with each module list sorted by disclosure date.
     def sort_date_in_group(bap_groups)
       bap_groups.each_pair do |ranking, module_list|
-        # TODO: Handle wonky dates in local modules better - HD
-        bap_groups[ranking] = module_list.sort_by {|m| Date.parse(m.disclosure_date.to_s)}.reverse
+        bap_groups[ranking] = module_list.sort_by {|m|
+          dstr = m.disclosure_date || "1970-01-01"
+          Date.parse(dstr) rescue Date.parse("1970-01-01")
+        }.reverse
       end
     end
 
@@ -337,8 +339,9 @@ module Msf
         # Configurable only by BAP
         multi_handler.datastore['ExitOnSession'] = false
         multi_handler.datastore['EXITFUNC']      = 'thread'
-        multi_handler.datastore['WORKSPACE']     = self.workspace
 
+        # Register this module as a child and copy datastore options
+        multi_handler.register_parent(self)
 
         # Now we're ready to start the handler
         multi_handler.exploit_simple(


### PR DESCRIPTION
- Use module.register_parent() to pass WORKSPACE and other fields
- Prevent partial resource matching in URIs
- Make disclosure_date sorting resilient
