### PR TITLE
Remove more peers

### DIFF
--- a/modules/auxiliary/admin/mssql/mssql_escalate_dbowner_sqli.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_dbowner_sqli.rb
@@ -89,10 +89,6 @@ class Metasploit3 < Msf::Auxiliary
     end
   end
 
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def get_username
     # Setup query to check for database username
     clue_start = Rex::Text.rand_text_alpha(8 + rand(4))

--- a/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
@@ -43,10 +43,6 @@ class Metasploit3 < Msf::Auxiliary
     res
   end
 
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def run_host(ip)
     vprint_status("#{peer} - Login...")
 

--- a/modules/auxiliary/scanner/smtp/smtp_relay.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_relay.rb
@@ -38,10 +38,6 @@ class Metasploit3 < Msf::Auxiliary
       ], self.class)
   end
 
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def run_host(ip)
     begin
       connect

--- a/modules/exploits/windows/mysql/mysql_mof.rb
+++ b/modules/exploits/windows/mysql/mysql_mof.rb
@@ -59,10 +59,6 @@ class Metasploit3 < Msf::Exploit::Remote
     return Exploit::CheckCode::Safe
   end
 
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def query(q)
     rows = []
 

--- a/modules/exploits/windows/mysql/mysql_start_up.rb
+++ b/modules/exploits/windows/mysql/mysql_start_up.rb
@@ -64,10 +64,6 @@ class Metasploit3 < Msf::Exploit::Remote
     Exploit::CheckCode::Safe
   end
 
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def query(q)
     rows = []
 

--- a/modules/post/multi/manage/play_youtube.rb
+++ b/modules/post/multi/manage/play_youtube.rb
@@ -31,11 +31,6 @@ class Metasploit3 < Msf::Post
       ], self.class)
   end
 
-  def peer
-    "#{session.session_host}:#{session.session_port}"
-  end
-
-
   #
   # The OSX version uses an apple script to do this
   #

--- a/modules/post/osx/gather/safari_lastsession.rb
+++ b/modules/post/osx/gather/safari_lastsession.rb
@@ -58,11 +58,6 @@ class Metasploit3 < Msf::Post
     version
   end
 
-  def peer
-    "#{session.session_host}:#{session.session_port}"
-  end
-
-
   #
   # Converts LastSession.plist to xml, and then read it
   # @param filename [String] The path to LastSession.plist

--- a/modules/post/windows/gather/credentials/smartermail.rb
+++ b/modules/post/windows/gather/credentials/smartermail.rb
@@ -38,22 +38,6 @@ class Metasploit3 < Msf::Post
     ))
   end
 
-  def r_host
-    if session.type =~ /meterpreter/
-      session.sock.peerhost
-    else
-      session.session_host
-    end
-  end
-
-  def peer
-    if session.type =~ /meterpreter/
-      "#{r_host} (#{sysinfo['Computer']})"
-    else
-      r_host
-    end
-  end
-
   #
   # Decrypt DES encrypted password string
   #
@@ -215,7 +199,7 @@ class Metasploit3 < Msf::Post
     print_good "#{peer} - Found Username: '#{user}' Password: '#{pass}'"
 
     report_cred(
-      ip: r_host,
+      ip: rhost,
       port: port,
       service_name: 'http',
       user: user,


### PR DESCRIPTION
The smtp, smtp, mysql and post mixins also `def peer`, so these other modules can simply rely on that rather than reimplementing their own.

re: https://github.com/rapid7/metasploit-framework/pull/6392
